### PR TITLE
Throw SOAP exception when unable to connect to VIES server

### DIFF
--- a/src/Ddeboer/Vatin/Vies/Client.php
+++ b/src/Ddeboer/Vatin/Vies/Client.php
@@ -73,7 +73,8 @@ class Client
                 array(
                     'classmap' => $this->classmap,
                     'user_agent' => 'Mozilla', // the request fails unless a (dummy) user agent is specified
-               )
+                    'exceptions' => true,
+                )
             );
         }
 

--- a/tests/Ddeboer/Vatin/Test/ValidatorTest.php
+++ b/tests/Ddeboer/Vatin/Test/ValidatorTest.php
@@ -4,6 +4,7 @@ namespace Ddeboer\Vatin\Test;
 
 use Ddeboer\Vatin\Validator;
 use Ddeboer\Vatin\Test\Mock\Vies\Response\CheckVatResponse;
+use Ddeboer\Vatin\Vies\Client;
 
 class ValidatorTest extends \PHPUnit_Framework_TestCase
 {
@@ -59,6 +60,15 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
 
         $this->validator->setViesClient($client);
         $this->assertFalse($this->validator->isValid('NL123456789B01', true));
+    }
+
+
+    public function testWrongConnectionThrowsException()
+    {
+        $this->setExpectedException('\SoapFault');
+
+        $this->validator->setViesClient(new Client('http//google.com'));
+        $this->validator->isValid('NL002065538B01', true);
     }
 
     /**


### PR DESCRIPTION
VIES service is too often down and the connection fails. This causes a fatal error, which means we cannot respond to it. I've edited the vies/client.php settings so that an exception is thrown when the connection fails, so it can be catched. 
