### PR TITLE
Optionally catch WSDL client exceptions

### DIFF
--- a/src/Ddeboer/Vatin/Exception/ViesException.php
+++ b/src/Ddeboer/Vatin/Exception/ViesException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Ddeboer\Vatin\Exception;
+
+class ViesException extends \RuntimeException
+{
+
+}

--- a/src/Ddeboer/Vatin/Validator.php
+++ b/src/Ddeboer/Vatin/Validator.php
@@ -3,6 +3,7 @@
 namespace Ddeboer\Vatin;
 
 use Ddeboer\Vatin\Vies\Client;
+use Ddeboer\Vatin\Exception\ViesException;
 
 /**
  * Validate a VAT identification number (VATIN)

--- a/src/Ddeboer/Vatin/Vies/Client.php
+++ b/src/Ddeboer/Vatin/Vies/Client.php
@@ -2,6 +2,9 @@
 
 namespace Ddeboer\Vatin\Vies;
 
+use SoapFault;
+use Ddeboer\Vatin\Exception\ViesException;
+
 /**
  * A client for the VIES SOAP web service
  */
@@ -49,15 +52,20 @@ class Client
      * @param string $vatNumber   VAT number
      *
      * @return Response\CheckVatResponse
+     * @throws ViesException
      */
     public function checkVat($countryCode, $vatNumber)
     {
-        return $this->getSoapClient()->checkVat(
-            array(
-                'countryCode' => $countryCode,
-                'vatNumber' => $vatNumber
-            )
-        );
+        try {
+            return $this->getSoapClient()->checkVat(
+                array(
+                    'countryCode' => $countryCode,
+                    'vatNumber' => $vatNumber
+                )
+            );
+        } catch (SoapFault $e) {
+            throw new ViesException('Error communicating with VIES service', 0, $e);
+        }
     }
 
     /**

--- a/tests/Ddeboer/Vatin/Test/ValidatorTest.php
+++ b/tests/Ddeboer/Vatin/Test/ValidatorTest.php
@@ -65,7 +65,7 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
 
     public function testWrongConnectionThrowsException()
     {
-        $this->setExpectedException('\SoapFault');
+        $this->setExpectedException('\Ddeboer\Vatin\Exception\ViesException');
 
         $this->validator->setViesClient(new Client('http//google.com'));
         $this->validator->isValid('NL002065538B01', true);


### PR DESCRIPTION
This fixes #9 and #10 if a third parameter is passed to `Validator::isValid`.

When there is an error with the service, the third parameter becomes the return value, so set it to `true` to assume a valid number or `false` to assume an invalid number.

I'm not too sure whether it makes sense to have the default/null handled as it is currently, but I wanted to make sure that `testWrongConnectionThrowsException` passed. Any thoughts?