### PR TITLE
added many VAT IDs to unit test, extended Belgian and French VAT

### DIFF
--- a/src/Ddeboer/Vatin/Validator.php
+++ b/src/Ddeboer/Vatin/Validator.php
@@ -22,7 +22,7 @@ class Validator
      */
     protected $patterns = array(
         'AT' => 'U[A-Z\d]{8}',
-        'BE' => '0\d{9}',
+        'BE' => '[0|1]{1}\d{9}',
         'BG' => '\d{9,10}',
         'CY' => '\d{8}[A-Z]',
         'CZ' => '\d{8,10}',
@@ -32,7 +32,7 @@ class Validator
         'EL' => '\d{9}',
         'ES' => '[A-Z]\d{7}[A-Z]|\d{8}[A-Z]|[A-Z]\d{8}',
         'FI' => '\d{8}',
-        'FR' => '([A-Z]{2}|\d{2})\d{9}',
+        'FR' => '([A-Z0-9]{2})\d{9}',
         'GB' => '\d{9}|\d{12}|(GD|HA)\d{3}',
         'HR' => '\d{11}',
         'HU' => '\d{8}',

--- a/tests/Ddeboer/Vatin/Test/ValidatorTest.php
+++ b/tests/Ddeboer/Vatin/Test/ValidatorTest.php
@@ -77,6 +77,77 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
     public function getValidVatins()
     {
         return array(
+            // Examples from Wikipedia (https://en.wikipedia.org/wiki/VAT_identification_number)
+            array('ATU99999999'),       // Austria
+            array('BE0999999999'),      // Belgium
+            array('BE1999999999'),      // Belgium
+            array('HR12345678901'),     // Croatia
+            array('CY99999999L'),       // Cyprus
+            array('DK99999999'),        // Denmark
+            array('FI99999999'),        // Finland
+            array('FRXX999999999'),     // France
+            array('DE999999999'),       // Germany
+            array('HU12345678'),        // Hungary
+            array('IE1234567T'),        // Ireland
+            array('IE1234567TW'),       // Ireland
+            array('IE1234567FA'),       // Ireland (since January 2013)
+            array('NL999999999B99'),    // The Netherlands
+            array('ES99999999R'),       // Spain
+            array('SE999999999901'),    // Sweden
+            array('GB999999973'),       // United Kingdom (standard)
+            array('GBGD001'),           // United Kingdom (government departments)
+            array('GBHA599'),           // United Kingdom (health authorities)
+
+            // Examples from the EU (http://ec.europa.eu/taxation_customs/vies/faqvies.do#item_11)
+            array('ATU99999999'),       // AT-Austria
+            array('BE0999999999'),      // BE-Belgium
+            array('BG999999999'),       // BG-Bulgaria
+            array('BG9999999999'),      // BG-Bulgaria
+            array('CY99999999L'),       // CY-Cyprus
+            array('CZ99999999'),        // CZ-Czech Republic
+            array('CZ999999999'),       // CZ-Czech Republic
+            array('CZ9999999999'),      // CZ-Czech Republic
+            array('DE999999999'),       // DE-Germany
+            array('DK99999999'),        // DK-Denmark
+            array('EE999999999'),       // EE-Estonia
+            array('EL999999999'),       // EL-Greece
+            array('ESX9999999X'),       // ES-Spain
+            array('FI99999999'),        // FI-Finland
+            array('FRXX999999999'),     // FR-France
+            array('GB999999999'),       // GB-United Kingdom
+            array('GB999999999999'),    // GB-United Kingdom
+            array('GBGD999'),           // GB-United Kingdom
+            array('GBHA999'),           // GB-United Kingdom
+            array('HR99999999999'),     // HR-Croatia
+            array('HU99999999'),        // HU-Hungary
+            array('IE9S99999L'),        // IE-Ireland
+            array('IE9999999WI'),       // IE-Ireland
+            array('IT99999999999'),     // IT-Italy
+            array('LT999999999'),       // LT-Lithuania
+            array('LT999999999999'),    // LT-Lithuania
+            array('LU99999999'),        // LU-Luxembourg
+            array('LV99999999999'),     // LV-Latvia
+            array('MT99999999'),        // MT-Malta
+            array('NL999999999B99'),    // NL-The Netherlands
+            array('PL9999999999'),      // PL-Poland
+            array('PT999999999'),       // PT-Portugal
+            array('RO999999999'),       // RO-Romania
+            array('SE999999999999'),    // SE-Sweden
+            array('SI99999999'),        // SI-Slovenia
+            array('SK9999999999'),      // SK-Slovakia
+
+            // Real world examples
+            array('GB226148083'),       // Fuller's Brewery, United Kingdom
+            array('NL002230884B01'),    // Albert Heijn BV., The Netherlands
+            array('ESG82086810'),       // Fundación Telefónica, Spain
+            array('IE9514041I'),        // Lego Systems A/S, Denmark with Irish VAT ID
+            array('IE9990705T'),        // Amazon EU Sarl, Luxembourg with Irish VAT ID
+            array('DK61056416'),        // Carlsberg A/S, Denmark
+            array('BE0648836958'),      // Delhaize Logistics, Belgium
+            array('CZ00514152'),        // Budějovický Budvar, Budweiser, Czech Republic
+
+            // Various examples
+            array('FR9X999999999'),
             array('NL123456789B01'),
             array('IE9574245O')
         );
@@ -91,7 +162,8 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
             array(null),
             array(''),
             array('123456789'),
-            array('XX123')
+            array('XX123'),
+            array('BE2999999999'),      // Belgium - "the first digit following the prefix is always zero ("0") or ("1")"
         );
     }
 


### PR DESCRIPTION
Hello!

There were only a few numbers to check. I've added all examples I found on Wikipedia and on the EU page. I also updated Belgian and French VAT ID checks. Belgian VAT IDs can also begin with a leading zero, and French VAT IDs can be mixed with digits and letters at the first and second position.

Some sources:
* http://www.brighton-accountants.com/france/verify-vat-registration-number/
* https://en.wikipedia.org/wiki/VAT_identification_number
* http://ec.europa.eu/taxation_customs/vies/faqvies.do#item_11

Regards,
Timon