### PR TITLE
Don't export tests/ in Composer dist installs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+/tests export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.scrutinizer.yml export-ignore
+/.travis.yml export-ignore
+/phpunit.xml.dist export-ignore
+/README.md export-ignore

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ before_script:
   - travis_retry composer install --dev
 
 script:
+  - composer validate --strict
   - vendor/bin/phpunit --coverage-clover=coverage.clover
 
 after_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,15 @@ php:
   - 7.0
   - 7.1
 
-before_script:
-  - composer install --dev
+cache:
+  directories:
+    - $HOME/.composer/cache
 
-script: phpunit --coverage-clover=coverage.clover
+before_script:
+  - travis_retry composer install --dev
+
+script:
+  - vendor/bin/phpunit --coverage-clover=coverage.clover
 
 after_script:
   - wget https://scrutinizer-ci.com/ocular.phar

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     },
     "require-dev": {
         "ext-soap": "*",
-        "phpunit/phpunit": "^5.7"
+        "phpunit/phpunit": "^4.0 || ^5.0"
     },
     "suggest": {
         "ext-soap": "Required if you want to check the VAT number via VIES"

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
         "php": ">=5.3.0"
     },
     "require-dev": {
-        "ext-soap": "*"
+        "ext-soap": "*",
+        "phpunit/phpunit": "^5.7"
     },
     "suggest": {
         "ext-soap": "Required if you want to check the VAT number via VIES"


### PR DESCRIPTION
Don't export tests in composer dist installs. This ignores any non-code files in dist installs, speeding up installation.

Adds some caching for composer installs to travis.

Development requires PHPUnit (for test running), add it as a dependency. 