### PR TITLE
fix travis php5.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,16 @@
-sudo: false
-
 language: php
 
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6
   - 7.0
   - 7.1
+
+matrix:
+  include:
+    - php: 5.3
+      dist: precise
 
 cache:
   directories:

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     },
     "require-dev": {
         "ext-soap": "*",
-        "phpunit/phpunit": "^4.0 || ^5.0"
+        "phpunit/phpunit": "^4.8 || ^5.7"
     },
     "suggest": {
         "ext-soap": "Required if you want to check the VAT number via VIES"

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -6,7 +6,7 @@ use Ddeboer\Vatin\Validator;
 use Ddeboer\Vatin\Test\Mock\Vies\Response\CheckVatResponse;
 use Ddeboer\Vatin\Vies\Client;
 
-class ValidatorTest extends \PHPUnit_Framework_TestCase
+class ValidatorTest extends \PHPUnit\Framework\TestCase
 {
     private $validator;
 

--- a/tests/Vies/ClientTest.php
+++ b/tests/Vies/ClientTest.php
@@ -4,7 +4,7 @@ namespace Ddeboer\Vatin\Test\Vies;
 
 use Ddeboer\Vatin\Vies\Client;
 
-class ClientTest extends \PHPUnit_Framework_TestCase
+class ClientTest extends \PHPUnit\Framework\TestCase
 {
     public function testCheckVat()
     {


### PR DESCRIPTION
# Changed log

- The php 5.3 test needs the ```precise``` dist. Using the different distro in the Travis setting.
- Replace the PHPUnit name space.